### PR TITLE
Enable pixelated art

### DIFF
--- a/Build/TemplateData/style.css
+++ b/Build/TemplateData/style.css
@@ -16,3 +16,9 @@
 .webgl-content .footer .webgl-logo {background-image: url('webgl-logo.png'); width: 204px; float: left;}
 .webgl-content .footer .title {margin-right: 10px; float: right;}
 .webgl-content .footer .fullscreen {background-image: url('fullscreen.png'); width: 38px; float: right;}
+.webgl-content {
+    image-rendering: -webkit-crisp-edges; /* Safari */
+    image-rendering: -moz-crisp-edges; /* Firefox */
+    image-rendering: -o-crisp-edges; /* Opera */
+    image-rendering: pixelated; /* Chrome */
+}


### PR DESCRIPTION
This sets a few CSS properties so the art ends up looking pixelated, like in the original RPG Maker version, instead of filtered. Here's a couple screenshots from Firefox to show what it's like!

Original:

![screenshot_2018-09-29 unity webgl player pom gets wi-fi 1](https://user-images.githubusercontent.com/780485/46249725-b9153480-c3e2-11e8-8ea8-ef92c0d05aad.png)

This PR:

![screenshot_2018-09-29 unity webgl player pom gets wi-fi](https://user-images.githubusercontent.com/780485/46249726-bc102500-c3e2-11e8-811a-1be4bc662573.png)